### PR TITLE
enable additional environment config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,34 @@ module: {
 ...
 ```
 
+You can specify a `config` key with the path to a module for adding additional configuration to the nunjucks environment:
+```
+```javascript
+// nunjucks.loader.config.js
+const markdown = require('nunjucks-markdown');
+
+module.exports = function(env) {
+    markdown.register(env);
+}
+
+
+// webpack.config.js
+...
+module: {
+    loaders: [ {
+        // jinja/nunjucks templates
+        test: /\.jinja$/,
+        loader: 'jinja-loader',
+        query: {
+            root: /path/to/templates,
+            config: /path/to/nunjucks.loader.config.js
+        }
+    } ]
+}
+...
+```
+
+
 ## LICENSE
 
 MIT (http://www.opensource.org/licenses/mit-license.php)

--- a/index.js
+++ b/index.js
@@ -28,9 +28,16 @@ module.exports = function(source, map) {
     var query = loaderUtils.parseQuery(this.query);
     var root = query.root || '';
 
+    var env = new nunjucks.Environment(new nunjucks.FileSystemLoader(root));
+    if (query.config) {
+        var config = require(query.config);
+        config(env);
+    }
+
     // Name the template relatively to the `root`.
     var compiledTemplate = nunjucks.precompileString(source, {
-        name: this.resourcePath.replace(root, '')
+        name: this.resourcePath.replace(root, ''),
+        env: env
     });
 
     // Find template dependenciees and add the corresponding requires in the output


### PR DESCRIPTION
Hi, I needed to make changes to the environment to support the markdown tag. Here's my take on how it can be generalized to make general environment configuration changes before compiling. I'm not a node expert, but this worked for me! Please let me know if you see any issues.
